### PR TITLE
Øk antall tråder per partisjon

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/kafka/AivenKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/AivenKafkaConfig.kt
@@ -58,6 +58,7 @@ class AivenKafkaConfig(
         factory.consumerFactory = consumerFactory
         factory.setCommonErrorHandler(kafkaErrorHandler)
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
+        factory.setConcurrency(3)
         return factory
     }
 }


### PR DESCRIPTION
Hvis antall partisjoner er lavere enn concurrency, blir concurrency skalert ned av Spring.