### PR TITLE
Legg til kanal på JournalpostRequest

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/arkivering/SkapJournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/helse/flex/arkivering/SkapJournalpostRequest.kt
@@ -34,6 +34,7 @@ fun skapJournalpostRequest(
         sak = Sak(
             sakstype = "GENERELL_SAK"
         ),
+        kanal = "INGEN_DISTRIBUSJON",
         journalpostType = "UTGAAENDE",
         journalfoerendeEnhet = "9999",
         eksternReferanseId = id,


### PR DESCRIPTION
Meldingene vi arkiverer er ikke (fysisk) distribuert, så Team Dokumentløsning
vil at vi setter kanal til INGEN_DISTRIBUSJON.