### PR TITLE
Ferdigstill arkiverte

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ val kluentVersion = "1.68"
 val openHtmlToPdfVersion = "1.0.10"
 val verapdfVersion = "1.18.8"
 val jsoupVersion = "1.14.3"
+val mockitoKotlinVersion = "2.2.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
@@ -70,6 +71,7 @@ dependencies {
     testImplementation("no.nav.security:token-validation-spring-test:$tokenSupportVersion")
     testImplementation("org.awaitility:awaitility")
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion")
 }
 
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -11,6 +11,7 @@
   "ingress": "https://spinnsyn-arkivering.dev.nav.no",
   "env": {
     "SPINNSYN_FRONTEND_ARKIVERING_AAD_CLIENT_ID": "dev-gcp.flex.spinnsyn-frontend-arkivering",
+    "SPINNSYN_BACKEND_AAD_CLIENT_ID": "dev-gcp.flex.spinnsyn-backend",
     "SPRING_PROFILES_ACTIVE": "default,testcontroller",
     "DOKARKIV_AAD_CLIENT_ID": "972814f3-8bdf-44f8-a191-c2ed00020b54",
     "DOKARKIV_URL": "https://dokarkiv.dev-fss-pub.nais.io"

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -48,6 +48,7 @@ spec:
     outbound:
       rules:
         - application: spinnsyn-frontend-arkivering
+        - application: spinnsyn-backend
   kafka:
     pool: {{kafkaPool}}
   azure:

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -10,6 +10,7 @@
   "azureTenant": "nav.no",
   "env": {
     "SPINNSYN_FRONTEND_ARKIVERING_AAD_CLIENT_ID": "prod-gcp.flex.spinnsyn-frontend-arkivering",
+    "SPINNSYN_BACKEND_AAD_CLIENT_ID": "prod-gcp.flex.spinnsyn-backend",
     "DOKARKIV_AAD_CLIENT_ID": "162b3255-2f72-4399-8f7a-244add9ffaac",
     "DOKARKIV_URL": "https://dokarkiv.prod-fss-pub.nais.io"
   }

--- a/src/main/kotlin/no/nav/helse/flex/arkivering/ArkivertVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/arkivering/ArkivertVedtakRepository.kt
@@ -8,7 +8,7 @@ import java.time.Instant
 @Repository
 interface ArkivertVedtakRepository : CrudRepository<ArkivertVedtak, String> {
     fun existsByVedtakId(vedtakId: String): Boolean
-    fun getByVedtakId(vedtakId: String): Boolean
+    fun getByVedtakId(vedtakId: String): ArkivertVedtak
 }
 
 data class ArkivertVedtak(

--- a/src/main/kotlin/no/nav/helse/flex/arkivering/ArkivertVedtakRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/arkivering/ArkivertVedtakRepository.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 @Repository
 interface ArkivertVedtakRepository : CrudRepository<ArkivertVedtak, String> {
     fun existsByVedtakId(vedtakId: String): Boolean
+    fun getByVedtakId(vedtakId: String): Boolean
 }
 
 data class ArkivertVedtak(

--- a/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.client
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import no.nav.helse.flex.client.domain.JournalpostRequest
 import no.nav.helse.flex.client.domain.JournalpostResponse
 import org.springframework.beans.factory.annotation.Value
@@ -11,6 +12,7 @@ import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Controller
 import org.springframework.web.client.RestTemplate
+import java.time.LocalDateTime
 
 @Controller
 class DokArkivClient(
@@ -19,22 +21,49 @@ class DokArkivClient(
 ) {
 
     @Retryable(backoff = Backoff(delay = 5000))
-    fun opprettJournalpost(pdfRequest: JournalpostRequest, id: String): JournalpostResponse {
+    fun opprettJournalpost(pdfRequest: JournalpostRequest, vedtakId: String): JournalpostResponse {
         val url = "$dokarkivUrl/rest/journalpostapi/v1/journalpost?forsoekFerdigstill=true"
 
         val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
-        headers["Nav-Callid"] = id
+        headers["Nav-Callid"] = vedtakId
 
         val entity = HttpEntity(pdfRequest, headers)
 
         val result = dokarkivRestTemplate.exchange(url, HttpMethod.POST, entity, JournalpostResponse::class.java)
 
         if (!result.statusCode.is2xxSuccessful) {
-            throw RuntimeException("dokarkiv feiler med HTTP-${result.statusCode} for vedtak med id: $id")
+            throw RuntimeException("dokarkiv feiler med HTTP-${result.statusCode} for vedtak med id: $vedtakId")
         }
 
         return result.body
-            ?: throw RuntimeException("dokarkiv returnerer ikke data for vedtak med id: $id")
+            ?: throw RuntimeException("dokarkiv returnerer ikke data for vedtak med id: $vedtakId")
+    }
+
+    @Retryable(backoff = Backoff(delay = 5000))
+    fun ferdigstillJournalpost(request: FerdigstillJournalpostRequest, vedtakId: String) {
+        val url = "$dokarkivUrl/rest/journalpostapi/v1/journalpost/${request.journalpostId}/ferdigstill"
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        val httpEntity = HttpEntity(request, headers)
+
+        val result = dokarkivRestTemplate.exchange(url, HttpMethod.PATCH, httpEntity, Void::class.java)
+
+        if (!result.statusCode.is2xxSuccessful) {
+            throw RuntimeException(
+                "Ferdigstilling av journalpost feiler med HTTP-${result.statusCode} ${result.statusCodeValue} for " +
+                    "vedtak med id: $vedtakId og journalpostId: ${request.journalpostId}."
+            )
+        }
     }
 }
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class FerdigstillJournalpostRequest(
+    val journalfoerendeEnhet: String,
+    val journalpostId: String,
+    val datoJournal: LocalDateTime
+)
+

--- a/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
@@ -12,7 +12,7 @@ import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Controller
 import org.springframework.web.client.RestTemplate
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Controller
 class DokArkivClient(
@@ -64,6 +64,5 @@ class DokArkivClient(
 data class FerdigstillJournalpostRequest(
     val journalfoerendeEnhet: String,
     val journalpostId: String,
-    val datoJournal: LocalDateTime
+    val datoJournal: LocalDate
 )
-

--- a/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
@@ -50,7 +50,6 @@ class DokArkivClient(
         val httpEntity = HttpEntity(request, headers)
 
         val result = dokarkivRestTemplate.exchange(url, HttpMethod.PATCH, httpEntity, Void::class.java)
-
         if (!result.statusCode.is2xxSuccessful) {
             throw RuntimeException(
                 "Ferdigstilling av journalpost feiler med HTTP-${result.statusCode} ${result.statusCodeValue} for " +

--- a/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
@@ -44,6 +44,19 @@ class AadRestTemplateConfiguration {
             oAuth2AccessTokenService = oAuth2AccessTokenService,
         )
 
+    @Bean
+    fun spinnsynBackendRestTemplate(
+        restTemplateBuilder: RestTemplateBuilder,
+        clientConfigurationProperties: ClientConfigurationProperties,
+        oAuth2AccessTokenService: OAuth2AccessTokenService
+    ): RestTemplate =
+        downstreamRestTemplate(
+            registrationName = "spinnsyn-backend-credentials",
+            restTemplateBuilder = restTemplateBuilder,
+            clientConfigurationProperties = clientConfigurationProperties,
+            oAuth2AccessTokenService = oAuth2AccessTokenService,
+        )
+
     private fun downstreamRestTemplate(
         restTemplateBuilder: RestTemplateBuilder,
         clientConfigurationProperties: ClientConfigurationProperties,

--- a/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
@@ -9,8 +9,10 @@ import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpRequest
+import org.springframework.http.MediaType
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.web.client.RestTemplate
 
 @EnableJwtTokenValidation
@@ -49,13 +51,19 @@ class AadRestTemplateConfiguration {
         restTemplateBuilder: RestTemplateBuilder,
         clientConfigurationProperties: ClientConfigurationProperties,
         oAuth2AccessTokenService: OAuth2AccessTokenService
-    ): RestTemplate =
-        downstreamRestTemplate(
+    ): RestTemplate {
+        val restTemplate = downstreamRestTemplate(
             registrationName = "spinnsyn-backend-credentials",
             restTemplateBuilder = restTemplateBuilder,
             clientConfigurationProperties = clientConfigurationProperties,
             oAuth2AccessTokenService = oAuth2AccessTokenService,
         )
+        // For å kunne deserialisere Array<RSVedtakWrapper>::class.java.
+        val jacksonMessageConverter = MappingJackson2HttpMessageConverter()
+        jacksonMessageConverter.supportedMediaTypes = listOf(MediaType.APPLICATION_OCTET_STREAM)
+        restTemplate.messageConverters.add(jacksonMessageConverter)
+        return restTemplate
+    }
 
     private fun downstreamRestTemplate(
         restTemplateBuilder: RestTemplateBuilder,

--- a/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
@@ -28,7 +28,7 @@ class ArkiveringListener(
             "Lest vedtak med id: ${arkivertVedtakDto.id} fra topic: $FLEX_VEDTAK_ARKIVERING_TOPIC, " +
                 "partisjon: ${cr.partition()} og offset: ${cr.offset()}."
         )
-        ferdigstillArkiverteService.ferdigstillArkivertVedtak(arkivertVedtakDto)
+        ferdigstillArkiverteService.ferdigstillVedtak(arkivertVedtakDto)
         acknowledgment.acknowledge()
     }
 

--- a/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
@@ -1,0 +1,39 @@
+package no.nav.helse.flex.kafka
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.helse.flex.logger
+import no.nav.helse.flex.objectMapper
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class ArkiveringListener() {
+
+    private val log = logger()
+
+    @KafkaListener(
+        topics = [FLEX_VEDTAK_ARKIVERING_TOPIC],
+        containerFactory = "aivenKafkaListenerContainerFactory",
+        properties = ["auto.offset.reset = earliest"],
+        groupId = "spinnsyn-arkivering-ferdigstilling"
+    )
+    fun listen(cr: ConsumerRecord<String, String>, acknowledgment: Acknowledgment) {
+        val vedtak = cr.value().tilUarkivertVedtak()
+        log.info(
+            "Lest vedtak med id: ${vedtak.id} fra topic: $FLEX_VEDTAK_ARKIVERING_TOPIC, " +
+                "partisjon: ${cr.partition()} og offset: ${cr.offset()}."
+        )
+        acknowledgment.acknowledge()
+    }
+
+    fun String.tilUarkivertVedtak(): VedtakArkiveringDTO = objectMapper.readValue(this)
+}
+
+const val FLEX_VEDTAK_ARKIVERING_TOPIC = "flex.vedtak-arkivering"
+
+data class VedtakArkiveringDTO(
+    val fnr: String,
+    val id: String,
+)

--- a/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
@@ -3,13 +3,16 @@ package no.nav.helse.flex.kafka
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.flex.logger
 import no.nav.helse.flex.objectMapper
+import no.nav.helse.flex.uarkiverte.FerdigstillArkiverteService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
 
 @Component
-class ArkiveringListener() {
+class ArkiveringListener(
+    private val ferdigstillArkiverteService: FerdigstillArkiverteService
+) {
 
     private val log = logger()
 
@@ -20,20 +23,21 @@ class ArkiveringListener() {
         groupId = "spinnsyn-arkivering-ferdigstilling"
     )
     fun listen(cr: ConsumerRecord<String, String>, acknowledgment: Acknowledgment) {
-        val vedtak = cr.value().tilUarkivertVedtak()
+        val arkivertVedtakDto = cr.value().tilArkivertVedtakDto()
         log.info(
-            "Lest vedtak med id: ${vedtak.id} fra topic: $FLEX_VEDTAK_ARKIVERING_TOPIC, " +
+            "Lest vedtak med id: ${arkivertVedtakDto.id} fra topic: $FLEX_VEDTAK_ARKIVERING_TOPIC, " +
                 "partisjon: ${cr.partition()} og offset: ${cr.offset()}."
         )
+        ferdigstillArkiverteService.ferdigstillArkivertVedtak(arkivertVedtakDto)
         acknowledgment.acknowledge()
     }
 
-    fun String.tilUarkivertVedtak(): VedtakArkiveringDTO = objectMapper.readValue(this)
+    fun String.tilArkivertVedtakDto(): ArkivertVedtakDto = objectMapper.readValue(this)
 }
 
 const val FLEX_VEDTAK_ARKIVERING_TOPIC = "flex.vedtak-arkivering"
 
-data class VedtakArkiveringDTO(
+data class ArkivertVedtakDto(
     val fnr: String,
     val id: String,
 )

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -19,9 +19,12 @@ class FerdigstillArkiverteService(
 
     fun ferdigstillArkivertVedtak(vedtakDto: ArkivertVedtakDto) {
         val journalPostId = hentJournalPostId(vedtakDto.id)
-        log.info("Hentet journalpostId: $journalPostId for vedtakId ${vedtakDto.id}")
+        log.info("Hentet journalpostId: $journalPostId for vedtakId ${vedtakDto.id}.")
+
+        val datoJournal = hentOpprettetDato(vedtakDto.fnr, vedtakDto.id)
+        log.info("Hentet datoJournal: $datoJournal for vedtakId ${vedtakDto.id} fra spinnsyn-backend.")
+
         /*
-        val datoJournal = hentOpprettetDato(vedtakDto.id, vedtakDto.id)
         val vedtakId = vedtakDto.id
 
         val request = FerdigstillJournalpostRequest(

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -1,0 +1,35 @@
+package no.nav.helse.flex.uarkiverte
+
+import no.nav.helse.flex.client.DokArkivClient
+import no.nav.helse.flex.client.FerdigstillJournalpostRequest
+import no.nav.helse.flex.kafka.ArkivertVedtakDto
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class FerdigstillArkiverteService(
+    private val dokArkivClient: DokArkivClient
+) {
+
+    fun ferdigstillArkivertVedtak(arkivertVedtakDto: ArkivertVedtakDto) {
+        val journalPostId = finnJournalPostId(arkivertVedtakDto.id)
+        val datoJournal = hentOpprettetDato(arkivertVedtakDto.id, arkivertVedtakDto.id)
+        val vedtakId = arkivertVedtakDto.id
+
+        val request = FerdigstillJournalpostRequest(
+            journalfoerendeEnhet = "9999",
+            journalpostId = journalPostId,
+            datoJournal = datoJournal
+        )
+        dokArkivClient.ferdigstillJournalpost(request = request, vedtakId = vedtakId)
+    }
+
+    private fun finnJournalPostId(id: String): String {
+        TODO("Not yet implemented")
+    }
+
+    private fun hentOpprettetDato(fnr: String, id: String): LocalDateTime {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -5,7 +5,7 @@ import no.nav.helse.flex.client.DokArkivClient
 import no.nav.helse.flex.client.FerdigstillJournalpostRequest
 import no.nav.helse.flex.kafka.ArkivertVedtakDto
 import org.springframework.stereotype.Service
- import java.time.LocalDate
+import java.time.LocalDate
 
 @Service
 class FerdigstillArkiverteService(

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -4,6 +4,7 @@ import no.nav.helse.flex.arkivering.ArkivertVedtakRepository
 import no.nav.helse.flex.client.DokArkivClient
 import no.nav.helse.flex.client.FerdigstillJournalpostRequest
 import no.nav.helse.flex.kafka.ArkivertVedtakDto
+import no.nav.helse.flex.logger
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -14,8 +15,12 @@ class FerdigstillArkiverteService(
     private val spinnsynClient: SpinnsynBackendRestClient,
 ) {
 
+    private val log = logger()
+
     fun ferdigstillArkivertVedtak(vedtakDto: ArkivertVedtakDto) {
         val journalPostId = hentJournalPostId(vedtakDto.id)
+        log.info("Hentet journalpostId: $journalPostId for vedtakId ${vedtakDto.id}")
+        /*
         val datoJournal = hentOpprettetDato(vedtakDto.id, vedtakDto.id)
         val vedtakId = vedtakDto.id
 
@@ -25,6 +30,7 @@ class FerdigstillArkiverteService(
             datoJournal = datoJournal
         )
         dokArkivClient.ferdigstillJournalpost(request = request, vedtakId = vedtakId)
+         */
     }
 
     private fun hentJournalPostId(id: String): String {

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.uarkiverte
 
+import no.nav.helse.flex.arkivering.ArkivertVedtakRepository
 import no.nav.helse.flex.client.DokArkivClient
 import no.nav.helse.flex.client.FerdigstillJournalpostRequest
 import no.nav.helse.flex.kafka.ArkivertVedtakDto
@@ -8,7 +9,8 @@ import java.time.LocalDateTime
 
 @Service
 class FerdigstillArkiverteService(
-    private val dokArkivClient: DokArkivClient
+    private val dokArkivClient: DokArkivClient,
+    private val arkivertVedtakRepository: ArkivertVedtakRepository,
 ) {
 
     fun ferdigstillArkivertVedtak(arkivertVedtakDto: ArkivertVedtakDto) {
@@ -25,11 +27,10 @@ class FerdigstillArkiverteService(
     }
 
     private fun finnJournalPostId(id: String): String {
-        TODO("Not yet implemented")
+        return arkivertVedtakRepository.getByVedtakId(id).journalpostId
     }
 
     private fun hentOpprettetDato(fnr: String, id: String): LocalDateTime {
         TODO("Not yet implemented")
     }
-
 }

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -19,21 +19,16 @@ class FerdigstillArkiverteService(
 
     fun ferdigstillArkivertVedtak(vedtakDto: ArkivertVedtakDto) {
         val journalPostId = hentJournalPostId(vedtakDto.id)
-        log.info("Hentet journalpostId: $journalPostId for vedtakId ${vedtakDto.id}.")
-
         val datoJournal = hentOpprettetDato(vedtakDto.fnr, vedtakDto.id)
-        log.info("Hentet datoJournal: $datoJournal for vedtakId ${vedtakDto.id} fra spinnsyn-backend.")
-
-        /*
-        val vedtakId = vedtakDto.id
 
         val request = FerdigstillJournalpostRequest(
             journalfoerendeEnhet = "9999",
             journalpostId = journalPostId,
             datoJournal = datoJournal
         )
-        dokArkivClient.ferdigstillJournalpost(request = request, vedtakId = vedtakId)
-         */
+        dokArkivClient.ferdigstillJournalpost(request = request, vedtakId = vedtakDto.id)
+
+        log.info("Ferdigstilt vedtak med id: ${vedtakDto.id}, journalpostId: $journalPostId og datoJournal: $datoJournal.")
     }
 
     private fun hentJournalPostId(id: String): String {

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/FerdigstillArkiverteService.kt
@@ -5,18 +5,19 @@ import no.nav.helse.flex.client.DokArkivClient
 import no.nav.helse.flex.client.FerdigstillJournalpostRequest
 import no.nav.helse.flex.kafka.ArkivertVedtakDto
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
+ import java.time.LocalDate
 
 @Service
 class FerdigstillArkiverteService(
     private val dokArkivClient: DokArkivClient,
-    private val arkivertVedtakRepository: ArkivertVedtakRepository,
+    private val arkivertRepository: ArkivertVedtakRepository,
+    private val spinnsynClient: SpinnsynBackendRestClient,
 ) {
 
-    fun ferdigstillArkivertVedtak(arkivertVedtakDto: ArkivertVedtakDto) {
-        val journalPostId = finnJournalPostId(arkivertVedtakDto.id)
-        val datoJournal = hentOpprettetDato(arkivertVedtakDto.id, arkivertVedtakDto.id)
-        val vedtakId = arkivertVedtakDto.id
+    fun ferdigstillArkivertVedtak(vedtakDto: ArkivertVedtakDto) {
+        val journalPostId = hentJournalPostId(vedtakDto.id)
+        val datoJournal = hentOpprettetDato(vedtakDto.id, vedtakDto.id)
+        val vedtakId = vedtakDto.id
 
         val request = FerdigstillJournalpostRequest(
             journalfoerendeEnhet = "9999",
@@ -26,11 +27,11 @@ class FerdigstillArkiverteService(
         dokArkivClient.ferdigstillJournalpost(request = request, vedtakId = vedtakId)
     }
 
-    private fun finnJournalPostId(id: String): String {
-        return arkivertVedtakRepository.getByVedtakId(id).journalpostId
+    private fun hentJournalPostId(id: String): String {
+        return arkivertRepository.getByVedtakId(id).journalpostId
     }
 
-    private fun hentOpprettetDato(fnr: String, id: String): LocalDateTime {
-        TODO("Not yet implemented")
+    private fun hentOpprettetDato(fnr: String, id: String): LocalDate {
+        return spinnsynClient.hentVedtak(fnr).first { vedtak -> vedtak.id == id }.opprettet
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
@@ -1,0 +1,24 @@
+package no.nav.helse.flex.uarkiverte
+
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class SpinnsynBackendRestClient {
+
+    fun hentVedtak(fnr: String): List<Vedtak> {
+        TODO("Not yet implemented")
+    }
+
+    private data class RSVedtakWrapper(
+        val id: String,
+        val opprettet: LocalDate,
+    )
+
+    private fun RSVedtakWrapper.tilVedtak(): Vedtak = Vedtak(this.id, this.opprettet)
+}
+
+data class Vedtak(
+    val id: String,
+    val opprettet: LocalDate,
+)

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
@@ -1,6 +1,5 @@
 package no.nav.helse.flex.uarkiverte
 
-import no.nav.helse.flex.logger
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
@@ -1,6 +1,6 @@
 package no.nav.helse.flex.uarkiverte
 
-import no.nav.helse.flex.client.VedtakIkkeFunnetException
+import no.nav.helse.flex.logger
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -35,7 +35,7 @@ class SpinnsynBackendRestClient(
             ?: throw TomVedtaksListeException("Spinnsyn Backend returnerte ingen vedtak.")
     }
 
-    private data class RSVedtakWrapper(
+    data class RSVedtakWrapper(
         val id: String,
         val opprettet: LocalDate,
     )

--- a/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/uarkiverte/SpinnsynBackendRestClient.kt
@@ -1,13 +1,38 @@
 package no.nav.helse.flex.uarkiverte
 
+import no.nav.helse.flex.client.VedtakIkkeFunnetException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
 import java.time.LocalDate
 
 @Component
-class SpinnsynBackendRestClient {
+class SpinnsynBackendRestClient(
+    private val spinnsynBackendRestTemplate: RestTemplate,
+    @Value("\${spinnsyn.backend.url}") private val spinnsynBackendUrl: String
+) {
 
+    @Retryable(exclude = [TomVedtaksListeException::class])
     fun hentVedtak(fnr: String): List<Vedtak> {
-        TODO("Not yet implemented")
+        val url = "$spinnsynBackendUrl/api/v1/arkivering/vedtak"
+
+        val headers = HttpHeaders()
+        headers["fnr"] = fnr
+        val entity = HttpEntity<Any>(headers)
+
+        // Kaster RestTemplateException for alle 4xx og 5xx HTTP statuskoder, som trigger retry.
+        val result = spinnsynBackendRestTemplate.exchange(
+            url, HttpMethod.GET, entity, Array<RSVedtakWrapper>::class.java
+        )
+
+        // Vi har en 200 OK, men med tom liste. Gjør ikke retry. Dette skal ikke skje da vi vet vi leser fnr fra
+        // vedtak som allerede er arkivert.
+        return result.body?.map { vedtakWrapper -> vedtakWrapper.tilVedtak() }?.toList()
+            ?: throw TomVedtaksListeException("Spinnsyn Backend returnerte ingen vedtak.")
     }
 
     private data class RSVedtakWrapper(
@@ -21,4 +46,8 @@ class SpinnsynBackendRestClient {
 data class Vedtak(
     val id: String,
     val opprettet: LocalDate,
+)
+
+class TomVedtaksListeException(message: String) : RuntimeException(
+    message
 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,14 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      spinnsyn-backend-credentials:
+        token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+        grant-type: client_credentials
+        scope: api://${SPINNSYN_BACKEND_AAD_CLIENT_ID}/.default
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       dokarkiv-client-credentials:
         token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
         grant-type: client_credentials
@@ -48,4 +56,5 @@ management:
 
 logging.config: "classpath:logback.xml"
 spinnsyn.frontend.arkivering.url: "http://spinnsyn-frontend-arkivering"
+spinnsyn.backend.url: "http://spinnsyn-backend"
 nais.cluster: ${NAIS_CLUSTER_NAME}

--- a/src/test/kotlin/no/nav/helse/flex/FerdigstillArkiverteTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FerdigstillArkiverteTest.kt
@@ -1,0 +1,43 @@
+package no.nav.helse.flex
+
+import com.nhaarman.mockitokotlin2.whenever
+import no.nav.helse.flex.arkivering.ArkivertVedtakRepository
+import no.nav.helse.flex.client.DokArkivClient
+import no.nav.helse.flex.kafka.ArkivertVedtakDto
+import no.nav.helse.flex.uarkiverte.FerdigstillArkiverteService
+import no.nav.helse.flex.uarkiverte.SpinnsynBackendRestClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.dao.DataRetrievalFailureException
+
+@ExtendWith(MockitoExtension::class)
+class FerdigstillArkiverteTest {
+
+    @Mock
+    private lateinit var spinnsynRestClient: SpinnsynBackendRestClient
+
+    @Mock
+    private lateinit var dokarkivRestClient: DokArkivClient
+
+    @Mock
+    private lateinit var arkiverteRepository: ArkivertVedtakRepository
+
+    @InjectMocks
+    private lateinit var ferdigstillArkiverteService: FerdigstillArkiverteService
+
+    @Test
+    fun `REST-endepunkt blir ikke kalt når vedtaket ikke er arkivert`() {
+
+        whenever(arkiverteRepository.getByVedtakId("vedtak-1"))
+            .thenThrow(DataRetrievalFailureException("Test"))
+
+        ferdigstillArkiverteService.ferdigstillVedtak(ArkivertVedtakDto("fnr-1", "vedtak-1"))
+
+        verifyNoInteractions(spinnsynRestClient)
+        verifyNoInteractions(dokarkivRestClient)
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/FerdigstillUarkiverteTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FerdigstillUarkiverteTest.kt
@@ -1,0 +1,65 @@
+package no.nav.helse.flex
+
+import no.nav.helse.flex.kafka.ArkivertVedtakDto
+import no.nav.helse.flex.kafka.FLEX_VEDTAK_ARKIVERING_TOPIC
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class FerdigstillUarkiverteTest() : Testoppsett() {
+
+    @Autowired
+    lateinit var kafkaProducer: KafkaProducer<String, String>
+
+    private val vedtakId = UUID.randomUUID().toString()
+    private val fnr = "12345678987"
+
+    @Test
+    fun `Arkivert vedtak blir ferdigstilt`() {
+        val vedtakId = "vedtak-1"
+        val fnr = "fnr-1"
+        val journalpostId = "journalpost-1"
+
+        opprettArkivertVedtak(vedtakId, fnr, journalpostId)
+
+        kafkaProducer.send(
+            ProducerRecord(
+                FLEX_VEDTAK_ARKIVERING_TOPIC,
+                null,
+                fnr,
+                ArkivertVedtakDto(fnr = fnr, id = vedtakId).serialisertTilString()
+            )
+        ).get()
+
+        // TODO: 1 - Verifisert at spinnsyn-backend blirt spurt om vedtakene. Returner liste med vedtak basert på fnr.
+        // TODO: 2 - Verifiser at Arkivet blir kallt
+
+        await().atMost(10, TimeUnit.SECONDS).until {
+            arkivertVedtakRepository.existsByVedtakId(vedtakId)
+        }
+    }
+
+    private fun opprettArkivertVedtak(vedtakId: String, fnr: String, journalpostId: String) {
+        namedParameterJdbcTemplate.update(
+            """
+            INSERT INTO arkivert_vedtak (id, vedtak_id, fnr, journalpost_id, opprettet, spinnsyn_frontend_image, spinnsyn_arkivering_image) 
+            VALUES (:id, :vedtak_id, :fnr, :journalpost_id, :opprettet, :frontend_image, :arkivering_image)
+        """,
+            MapSqlParameterSource()
+                .addValue("id", UUID.randomUUID().toString())
+                .addValue("vedtak_id", vedtakId)
+                .addValue("fnr", fnr)
+                .addValue("journalpost_id", journalpostId)
+                .addValue("opprettet", Timestamp.from(Instant.now()))
+                .addValue("frontend_image", "frontend_image")
+                .addValue("arkivering_image", "arkivering_image")
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/FerdigstillUarkiverteTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FerdigstillUarkiverteTest.kt
@@ -2,6 +2,11 @@ package no.nav.helse.flex
 
 import no.nav.helse.flex.kafka.ArkivertVedtakDto
 import no.nav.helse.flex.kafka.FLEX_VEDTAK_ARKIVERING_TOPIC
+import no.nav.helse.flex.uarkiverte.SpinnsynBackendRestClient
+import no.nav.helse.flex.uarkiverte.SpinnsynBackendRestClient.RSVedtakWrapper
+import okhttp3.mockwebserver.MockResponse
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldStartWith
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.awaitility.Awaitility.await
@@ -10,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDate
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -29,6 +35,11 @@ class FerdigstillUarkiverteTest() : Testoppsett() {
 
         opprettArkivertVedtak(vedtakId, fnr, journalpostId)
 
+        val spinnsynBackendResponse = listOf(RSVedtakWrapper(id = vedtakId, opprettet = LocalDate.now()))
+
+        val mockResponse = MockResponse().setBody(spinnsynBackendResponse.serialisertTilString())
+        spinnsynBackendMockWebServer.enqueue(mockResponse)
+
         kafkaProducer.send(
             ProducerRecord(
                 FLEX_VEDTAK_ARKIVERING_TOPIC,
@@ -38,12 +49,15 @@ class FerdigstillUarkiverteTest() : Testoppsett() {
             )
         ).get()
 
-        // TODO: 1 - Verifisert at spinnsyn-backend blirt spurt om vedtakene. Returner liste med vedtak basert på fnr.
-        // TODO: 2 - Verifiser at Arkivet blir kallt
+        val htmlRequest = spinnsynBackendMockWebServer.takeRequest()
 
-        await().atMost(10, TimeUnit.SECONDS).until {
-            arkivertVedtakRepository.existsByVedtakId(vedtakId)
-        }
+        htmlRequest.path `should be equal to` "/api/v1/arkivering/vedtak"
+        htmlRequest.headers["fnr"] `should be equal to` fnr
+        htmlRequest.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+
+        await().atMost(10, TimeUnit.SECONDS)
+
+        // TODO: 2 - Verifiser at Arkivet blir kallt
     }
 
     private fun opprettArkivertVedtak(vedtakId: String, fnr: String, journalpostId: String) {

--- a/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
@@ -26,6 +27,9 @@ abstract class Testoppsett {
 
     @Autowired
     lateinit var arkivertVedtakRepository: ArkivertVedtakRepository
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
 
     @Autowired
     lateinit var namedParameterJdbcTemplate: NamedParameterJdbcTemplate

--- a/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -25,6 +27,9 @@ abstract class Testoppsett {
 
     @Autowired
     lateinit var arkivertVedtakRepository: ArkivertVedtakRepository
+
+    @Autowired
+    lateinit var namedParameterJdbcTemplate: NamedParameterJdbcTemplate
 
     companion object {
         var spinnsynArkiveringFrontendMockWebServer: MockWebServer

--- a/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer

--- a/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
@@ -33,6 +33,7 @@ abstract class Testoppsett {
 
     companion object {
         var spinnsynArkiveringFrontendMockWebServer: MockWebServer
+        var spinnsynBackendMockWebServer: MockWebServer
         var dokarkivMockWebServer: MockWebServer
 
         init {
@@ -54,6 +55,12 @@ abstract class Testoppsett {
                 .also { it.start() }
                 .also {
                     System.setProperty("spinnsyn.frontend.arkivering.url", "http://localhost:${it.port}")
+                }
+
+            spinnsynBackendMockWebServer = MockWebServer()
+                .also { it.start() }
+                .also {
+                    System.setProperty("spinnsyn.backend.url", "http://localhost:${it.port}")
                 }
 
             dokarkivMockWebServer = MockWebServer()

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -19,9 +19,9 @@ KAFKA_SCHEMA_REGISTRY: ""
 KAFKA_SCHEMA_REGISTRY_USER: ""
 KAFKA_SCHEMA_REGISTRY_PASSWORD: ""
 
-
 logging.config: "classpath:logback-local.xml"
 spinnsyn.frontend.arkivering.url: "http://spinnsyn-frontend-arkivering"
+spinnsyn.backend.url: "http://spinnsyn-backend"
 
 no.nav.security.jwt:
   client:
@@ -30,6 +30,14 @@ no.nav.security.jwt:
         token-endpoint-url: http://localhost:${mock-oauth2-server.port}/azureator/token
         grant-type: client_credentials
         scope: spinnsyn-frontend-arkivering
+        authentication:
+          client-id: client-id
+          client-secret: secretzz
+          client-auth-method: client_secret_basic
+      spinnsyn-backend-credentials:
+        token-endpoint-url: http://localhost:${mock-oauth2-server.port}/azureator/token
+        grant-type: client_credentials
+        scope: spinnsyn-backend
         authentication:
           client-id: client-id
           client-secret: secretzz


### PR DESCRIPTION
Leser fra eksisterende Kafka-topic, henter opprettet-dato fra spinnsyn-backend og sender kall med ferdigstilling til dokumentarkivet. Kun happy-path test da dette er kode som skal kjøres én gang og overvåkes under kjøring. Ferdigstilling mot dokumentarkivet er også idempotent og kan kalles flere ganger om noe skulle gå galt. Flytter over i "dev-" branch før testing.