### PR TITLE
Håndter feil fra Dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/DokArkivClient.kt
@@ -40,7 +40,6 @@ class DokArkivClient(
             ?: throw RuntimeException("dokarkiv returnerer ikke data for vedtak med id: $vedtakId")
     }
 
-    @Retryable(backoff = Backoff(delay = 5000))
     fun ferdigstillJournalpost(
         journalpostId: String,
         journalpostRequest: FerdigstillJournalpostRequest,
@@ -52,14 +51,7 @@ class DokArkivClient(
         headers.contentType = MediaType.APPLICATION_JSON
 
         val httpEntity = HttpEntity(journalpostRequest, headers)
-
-        val result = dokarkivRestTemplate.exchange(url, HttpMethod.PATCH, httpEntity, Void::class.java)
-        if (!result.statusCode.is2xxSuccessful) {
-            throw RuntimeException(
-                "Ferdigstilling av journalpost feiler med HTTP-${result.statusCode} ${result.statusCodeValue} for " +
-                    "vedtak med id: $vedtakId og journalpostId: $journalpostId."
-            )
-        }
+        dokarkivRestTemplate.exchange(url, HttpMethod.PATCH, httpEntity, Void::class.java)
     }
 }
 

--- a/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/ArkiveringListener.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.flex.kafka
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.micrometer.core.instrument.MeterRegistry
 import no.nav.helse.flex.logger
 import no.nav.helse.flex.objectMapper
 import no.nav.helse.flex.uarkiverte.FerdigstillArkiverteService
@@ -11,7 +12,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class ArkiveringListener(
-    private val ferdigstillArkiverteService: FerdigstillArkiverteService
+    private val ferdigstillArkiverteService: FerdigstillArkiverteService,
+    private val registry: MeterRegistry
 ) {
 
     private val log = logger()
@@ -29,6 +31,7 @@ class ArkiveringListener(
                 "partisjon: ${cr.partition()} og offset: ${cr.offset()}."
         )
         ferdigstillArkiverteService.ferdigstillVedtak(arkivertVedtakDto)
+        registry.counter("ferdigstillt.arkivert").increment()
         acknowledgment.acknowledge()
     }
 

--- a/src/test/kotlin/no/nav/helse/flex/kafka/TestKafkaConfig.kt
+++ b/src/test/kotlin/no/nav/helse/flex/kafka/TestKafkaConfig.kt
@@ -29,7 +29,7 @@ class TestKafkaConfig(
     @Bean
     fun kafkaConsumer() = KafkaConsumer<String, String>(
         mapOf(
-            ConsumerConfig.GROUP_ID_CONFIG to "spinnsyn-arkivering-consumer",
+            ConsumerConfig.GROUP_ID_CONFIG to "spinnsyn-arkivering-ferdigstilling",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,


### PR DESCRIPTION
Commit Kafka-melding selv om Dokarkiv returnerer feil som gjør at det kastes en exception. Logger vedtakene som feiler for senere oppfølging.