### PR TITLE
Bump jsoup og veraPdf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,8 @@ val tokenSupportVersion = "2.0.20"
 val logstashLogbackEncoderVersion = "7.1.1"
 val kluentVersion = "1.68"
 val openHtmlToPdfVersion = "1.0.10"
-val verapdfVersion = "1.20.1"
-val jsoupVersion = "1.14.3"
+val verapdfVersion = "1.22.2"
+val jsoupVersion = "1.15.3"
 val mockitoKotlinVersion = "2.2.0"
 
 dependencies {

--- a/src/main/kotlin/no/nav/helse/flex/Application.kt
+++ b/src/main/kotlin/no/nav/helse/flex/Application.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.retry.annotation.EnableRetry
-import org.verapdf.pdfa.VeraGreenfieldFoundryProvider
+import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider
 
 @SpringBootApplication
 @EnableRetry

--- a/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/Testoppsett.kt
@@ -16,7 +16,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
-import org.verapdf.pdfa.VeraGreenfieldFoundryProvider
+import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider
 
 private class PostgreSQLContainer12 : PostgreSQLContainer<PostgreSQLContainer12>("postgres:12-alpine")
 

--- a/src/test/kotlin/no/nav/helse/flex/localtesting/Application.kt
+++ b/src/test/kotlin/no/nav/helse/flex/localtesting/Application.kt
@@ -12,7 +12,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ResponseBody
-import org.verapdf.pdfa.VeraGreenfieldFoundryProvider
+import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider
 import javax.servlet.http.HttpServletResponse
 
 @SpringBootApplication(


### PR DESCRIPTION
Breaking fordi restrukturerte pakker i veraPdf.

- Bump validation-model from 1.20.1 to 1.22.2
- Bump jsoup from 1.14.3 to 1.15.3