### PR TITLE
Oppgraderer Distroless til java17-debian11@sha256:b50c5d2f

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian11@sha256:12c7afb1875a0c01f2c0138698e619a1d39a8319fd40e020a6d8349cf5aae043
+FROM gcr.io/distroless/java17-debian11@sha256:b50c5d2f702a755dfaa18463edfd76c6cd0d8cb9a0e3073d99b8392b189aab24
 
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"


### PR DESCRIPTION
Fra flex-cli