### PR TITLE
Ssrf validering av UUID

### DIFF
--- a/src/test/kotlin/no/nav/helse/flex/HentingOgPdfGenereringTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/HentingOgPdfGenereringTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.flex
 import no.nav.helse.flex.arkivering.PdfSkaperen
 import no.nav.helse.flex.html.HtmlInliner
 import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,7 +30,8 @@ class HentingOgPdfGenereringTest : Testoppsett() {
         enqueFiler()
 
         val html = arkivaren.hentSomHtmlOgInlineTing(fnr, uuid)
-        val forventetHtml = HentingOgPdfGenereringTest::class.java.getResource("/forventet.html").readText()
+        val forventetHtml = HentingOgPdfGenereringTest::class.java.getResource("/forventet.html")?.readText()
+        assertNotNull(forventetHtml!!)
         html.html `should be equal to ignoring whitespace` forventetHtml
         validerRequests(uuid, fnr)
     }

--- a/src/test/kotlin/no/nav/helse/flex/HentingOgPdfGenereringTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/HentingOgPdfGenereringTest.kt
@@ -6,6 +6,7 @@ import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.client.RestClientException
 import java.io.File
 import java.time.Clock
 import java.time.Instant
@@ -102,5 +103,14 @@ class HentingOgPdfGenereringTest : Testoppsett() {
 
         val htmlRequest = spinnsynArkiveringFrontendMockWebServer.takeRequest()
         htmlRequest.path `should be equal to` "/syk/sykepenger/vedtak/arkivering/$uuid"
+    }
+
+    @Test
+    fun `sjekker at SSRF ikke er mulig`() {
+        val uuidMedUri = "?path=https://skummelnettside.net"
+
+        assertThrows(RestClientException::class.java) {
+            arkivaren.hentPdf(fnr, uuidMedUri)
+        }
     }
 }


### PR DESCRIPTION
La inn enkel sjekk av uuid for mindre sannsynlighet for SSRF angrep, etter forslag fra [code scanning](https://github.com/navikt/spinnsyn-arkivering/security/code-scanning/13)