### PR TITLE
Oppgraderer Distroless til java21-debian12@sha256:c298bfc8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12@sha256:903d5ad227a4afff8a207cd25c580ed059cc4006bb390eae65fb0361fc9724c3
+FROM gcr.io/distroless/java21-debian12@sha256:c298bfc8c8b1aa3d7b03480dcf52001a90d66d966f6a8d8997ae837d3982be3f
 
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=65.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"


### PR DESCRIPTION
Fra flex-cli